### PR TITLE
Fixed auth response bug that caused crash

### DIFF
--- a/lib/authentication/index.js
+++ b/lib/authentication/index.js
@@ -123,7 +123,7 @@ function checkSessionToken(requestObj, deferred) {
         .then(function (obj) {
             deferred.resolve(obj);
         }).catch(function (err) {
-            deferred.reject(err);
+            authFail(err, "AUTH_FAIL", deferred);
         }).done();
 }
 


### PR DESCRIPTION
Modified auth library, was previously causing a malformed
AuthResponse message to be sent when a user's session was expired.
Added code to fix it.
