### PR TITLE
More user model compatibility fixes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -240,7 +240,7 @@ program
         svmp.users.findUser({username: un})
             .then(function (user) {
                 // The user SHOULD NOT have a VM id or VM ip already set.
-                if (user.vm_id || user.vm_ip) {
+                if ((user.vm_id && user.vm_id.length > 0) || (user.vm_ip && user.vm_ip.length > 0)) {
                     throw new Error("User has VM or VM IP in record.");
                 } else {
                     return svmp.cloud.createAndStartVM(user, imageid, imageflvr)

--- a/lib/cloud/aws.js
+++ b/lib/cloud/aws.js
@@ -146,7 +146,7 @@ aws.createAndStartVM = function (user, image, flavor) {
                         user.vm_ip = server.addresses.private[0];
                     }
 
-                    if (user.vm_ip) {
+                    if (user.vm_ip && user.vm_ip.length > 0) {
                         createNameTag(user.vm_id, "svmp-user-instance_" + user.username + "-" + new Date().getTime() )
                             .then(function (obj) {
                                 deferred.resolve(user);
@@ -281,7 +281,7 @@ aws.destroyVM = function (obj, callback) {
     var deferred = Q.defer();
 
     // we only need to try to destroy the VM if the vm_id is defined
-    if (obj.vm_id) {
+    if (obj.vm_id && obj.vm_id.length > 0) {
         aws.computeClient.destroyServer(obj.vm_id, function (err, id) {
             if (err) {
                 deferred.reject(new Error("destroyVM failed: " + err));

--- a/lib/cloud/openstack.js
+++ b/lib/cloud/openstack.js
@@ -286,7 +286,7 @@ openstack.destroyVM = function (obj, callback) {
         .fin(function () {
             // destroying the VM has resolved
             // if we are using floating IPs, try to de-allocate this VMs IP
-            if (obj.vm_ip_id) {
+            if (obj.vm_ip_id && obj.vm_ip_id.length > 0) {
                 deallocateFloatingIp(obj)
                     // this is separate from destroying the VM, so if it fails, just print the error
                     .catch(function (e) {
@@ -296,7 +296,7 @@ openstack.destroyVM = function (obj, callback) {
         });
 
     // we only need to try to destroy the VM if the vm_id is defined
-    if (obj.vm_id) {
+    if (obj.vm_id && obj.vm_id.length > 0) {
         openstack.computeClient.destroyServer(obj.vm_id, function (err, id) {
             if (err) {
                 deferred.reject(new Error("destroyVM failed: " + err));

--- a/lib/model/users.js
+++ b/lib/model/users.js
@@ -190,7 +190,7 @@ exports.authenticateUser = function (obj, callback) {
 exports.removeUserVM = function (user) {
     var deferred = Q.defer();
 
-    if (!user.vm_id)
+    if (!user.vm_id || user.vm_id.length == 0)
         deferred.reject(new Error("removeUserVM failed, user '" + user.username + "' has no vm_id defined (was this user's vm_ip manually assigned?)"));
     else {
         var obj = {vm_id: user.vm_id, vm_ip: user.vm_ip, vm_ip_id: user.vm_ip_id};


### PR DESCRIPTION
New user model sets certain user properties (vm_id, vm_ip, and
vm_ip_id) to blank strings, where they were previously undefined.
This was breaking some checks that took place concerning cloud
providers.
