### PR TITLE
Fixed VM Session expiration bug

### DIFF
--- a/lib/model/vm-session.js
+++ b/lib/model/vm-session.js
@@ -33,7 +33,7 @@ var
 exports.create = function (token) {
     var username = token.sub;
     var connectTime = new Date();
-    var expireAt = token.exp;
+    var expireAt = token.exp * 1000; // convert expiration seconds to milliseconds
 
     svmp.logger.verbose("Calling overseer: services/vm-session for user '%s'", username);
 

--- a/lib/server/proxy.js
+++ b/lib/server/proxy.js
@@ -280,7 +280,7 @@ exports.handleConnection = function (clientSocket) {
         if (clientSocket.info.vmSession === null)
             return;
 
-        var expireMillis = (new Date(clientSocket.info.vmSession.expireAt * 1000) - new Date());
+        var expireMillis = (new Date(clientSocket.info.vmSession.expireAt) - new Date());
         svmp.logger.verbose("vmSession for '%s' expires in %d seconds", clientSocket.info.username, expireMillis / 1000);
 
         clientSocket.info.vmSessionTimeout = setTimeout(


### PR DESCRIPTION
Fixed bug where VM Session expiration dates did not match JWT
expiration dates. JWTs store dates in seconds, while VM Sessions
are Mongo documents that store dates in milliseconds. This bug
caused VM Sessions to get prematurely deleted by the Overseer,
which triggers VM resource cleanup.
